### PR TITLE
Item selling + inventory item stacking fix

### DIFF
--- a/game/world/managers/objects/player/InventoryManager.py
+++ b/game/world/managers/objects/player/InventoryManager.py
@@ -165,12 +165,15 @@ class InventoryManager(object):
                     dest_item.item_instance.stackcount += source_item.item_instance.stackcount
                     if source_bag in self.containers:
                         self.containers[source_bag].remove_item_in_slot(source_slot)
+                        RealmDatabaseManager.character_inventory_delete(source_item.item_instance)
                 else:
                     # Update stack values
                     source_item.item_instance.stackcount -= diff
                     dest_item.item_instance.stackcount = dest_item.item_template.stackable
+                    RealmDatabaseManager.character_inventory_update_item(source_item.item_instance)
 
                 self.owner.send_update_self()
+                RealmDatabaseManager.character_inventory_update_item(dest_item.item_instance)
                 return
 
             # Actual transfer

--- a/game/world/managers/objects/player/InventoryManager.py
+++ b/game/world/managers/objects/player/InventoryManager.py
@@ -245,6 +245,13 @@ class InventoryManager(object):
             return self.containers[bag].get_item(slot)
         return None
 
+    def get_item_info_by_guid(self, guid):
+        for container_slot, container in list(self.containers.items()):
+            for slot, item in list(container.sorted_slots.items()):
+                if item.guid == guid:
+                    return container_slot, container, slot, item
+        return None
+
     def add_bag(self, slot, container):
         if not self.is_bag_pos(slot):
             return False
@@ -348,6 +355,15 @@ class InventoryManager(object):
             error
         )
         self.owner.session.request.sendall(PacketWriter.get_packet(OpCode.SMSG_BUY_FAILED, data))
+
+    def send_sell_error(self, error, item_guid, vendor_guid=0):
+        data = pack(
+            '<QQB',
+            vendor_guid if vendor_guid > 0 else self.owner.guid,
+            item_guid,
+            error
+        )
+        self.owner.session.request.sendall(PacketWriter.get_packet(OpCode.SMSG_SELL_ITEM, data))
 
     def build_update(self, update_packet_factory):
         for slot, item in self.get_backpack().sorted_slots.items():

--- a/game/world/opcode_handling/Definitions.py
+++ b/game/world/opcode_handling/Definitions.py
@@ -42,6 +42,7 @@ from game.world.opcode_handling.handlers.PetitionBuyHandler import PetitionBuyHa
 from game.world.opcode_handling.handlers.ListInventoryHandler import ListInventoryHandler
 from game.world.opcode_handling.handlers.BuyItemHandler import BuyItemHandler
 from game.world.opcode_handling.handlers.AttackSwingHandler import AttackSwingHandler
+from game.world.opcode_handling.handlers.SellItemHandler import SellItemHandler
 
 from game.world.opcode_handling.handlers.MovementHandler import MovementHandler
 
@@ -96,6 +97,7 @@ HANDLER_DEFINITIONS = {
     OpCode.CMSG_LIST_INVENTORY: ListInventoryHandler.handle,
     OpCode.CMSG_BUY_ITEM: BuyItemHandler.handle,
     OpCode.CMSG_ATTACKSWING: AttackSwingHandler.handle,
+    OpCode.CMSG_SELL_ITEM: SellItemHandler.handle,
 
     OpCode.MSG_MOVE_HEARTBEAT: MovementHandler.handle_movement_status,
     OpCode.MSG_MOVE_UNROOT: MovementHandler.handle_movement_status,

--- a/game/world/opcode_handling/handlers/SellItemHandler.py
+++ b/game/world/opcode_handling/handlers/SellItemHandler.py
@@ -1,0 +1,57 @@
+from struct import pack, unpack
+
+from database.realm.RealmDatabaseManager import RealmDatabaseManager
+from utils.constants.ObjectCodes import SellResults
+
+
+class SellItemHandler(object):
+
+    @staticmethod
+    def handle(world_session, socket, reader):
+        if len(reader.data) >= 17:  # Avoid handling empty sell item packet
+            vendor_guid, item_guid, sell_amount = unpack('<QQB', reader.data[:17])
+            container_slot, container, slot, item = world_session.player_mgr.inventory.get_item_info_by_guid(item_guid)
+
+            if 0 < vendor_guid == world_session.player_mgr.current_selection:
+                if sell_amount <= 0:
+                    sell_amount = 1
+
+                if not item:
+                    world_session.player_mgr.inventory.send_sell_error(SellResults.SELL_ERR_CANT_FIND_ITEM,
+                                                                       item_guid, vendor_guid)
+                    return 0
+
+                owner = world_session.player_mgr.guid
+                if owner != item.item_instance.owner:
+                    world_session.player_mgr.inventory.send_sell_error(SellResults.SELL_ERR_YOU_DONT_OWN_THAT_ITEM,
+                                                                       item_guid, vendor_guid)
+                    return 0
+
+                stack_count = item.item_instance.stackcount
+
+                if sell_amount > stack_count:
+                    world_session.player_mgr.inventory.send_sell_error(SellResults.SELL_ERR_CANT_FIND_ITEM,
+                                                                       item_guid, vendor_guid)
+                    return 0
+
+                price = item.item_template.sell_price
+                if price == 0:  # Item is unsellable
+                    world_session.player_mgr.inventory.send_sell_error(SellResults.SELL_ERR_CANT_SELL_ITEM,
+                                                                       item_guid, vendor_guid)
+                    return 0
+
+                # Check if player is attempting to sell a bag with something in it
+                if world_session.player_mgr.inventory.is_bag_pos(slot) and not item.is_empty():
+                    world_session.player_mgr.inventory.send_sell_error(SellResults.SELL_ERR_ONLY_EMPTY_BAG,
+                                                                       item_guid, vendor_guid)
+                    return 0
+
+                if sell_amount < stack_count:
+                    item.item_instance.stackcount -= sell_amount
+                    RealmDatabaseManager.character_inventory_update_item(item.item_instance)
+                else:
+                    world_session.player_mgr.inventory.containers[container_slot].remove_item_in_slot(slot)
+                    RealmDatabaseManager.character_inventory_delete(item.item_instance)
+
+                world_session.player_mgr.mod_money(price * sell_amount)
+        return 0

--- a/game/world/opcode_handling/handlers/SellItemHandler.py
+++ b/game/world/opcode_handling/handlers/SellItemHandler.py
@@ -13,8 +13,6 @@ class SellItemHandler(object):
             container_slot, container, slot, item = world_session.player_mgr.inventory.get_item_info_by_guid(item_guid)
 
             if 0 < vendor_guid == world_session.player_mgr.current_selection:
-                if sell_amount <= 0:
-                    sell_amount = 1
 
                 if not item:
                     world_session.player_mgr.inventory.send_sell_error(SellResults.SELL_ERR_CANT_FIND_ITEM,
@@ -28,6 +26,10 @@ class SellItemHandler(object):
                     return 0
 
                 stack_count = item.item_instance.stackcount
+
+                # Client seems to send zero at least when simply right clicking, default to selling whole stack.
+                if sell_amount <= 0:
+                    sell_amount = stack_count
 
                 if sell_amount > stack_count:
                     world_session.player_mgr.inventory.send_sell_error(SellResults.SELL_ERR_CANT_FIND_ITEM,


### PR DESCRIPTION
Item selling adds the handler itself, sell error sending and a method for getting an item by it's guid from an inventory (I did not find an existing way to do it easily).
Second commit is a small fix for stacking - items were duplicated after relogging.