### PR TITLE
Implement BuyItemInSlot, fix add_item and can_store item stack checks

### DIFF
--- a/game/world/managers/objects/player/InventoryManager.py
+++ b/game/world/managers/objects/player/InventoryManager.py
@@ -201,7 +201,7 @@ class InventoryManager(object):
                     return
             else:
                 if handle_error:
-                    self.send_equip_error(InventoryError.BAG_SLOT_MISMATCH, None, dest_item)
+                    self.send_equip_error(InventoryError.BAG_NOT_EQUIPPABLE, None, dest_item)
                 return
 
         # Drags to bag slots
@@ -482,11 +482,11 @@ class InventoryManager(object):
         return bag_slot == InventorySlots.SLOT_INBACKPACK \
                and InventorySlots.SLOT_ITEM_START <= slot < InventorySlots.SLOT_ITEM_END
 
-    def send_equip_error(self, error, item_1=None, item_2=None):
+    def send_equip_error(self, error, item_1=None, item_2=None, required_level=0):
         data = pack('<B', error)
         if error != InventoryError.BAG_OK:
             if error == InventoryError.BAG_LEVEL_MISMATCH:
-                data += pack('<I', item_1.item_template.required_level if item_1 else 0)
+                data += pack('<I', item_1.item_template.required_level if item_1 else required_level)
             data += pack(
                 '<2QB',
                 item_1.guid if item_1 else self.owner.guid,

--- a/game/world/managers/objects/player/InventoryManager.py
+++ b/game/world/managers/objects/player/InventoryManager.py
@@ -162,7 +162,6 @@ class InventoryManager(object):
 
         # Destination slot checks
         if dest_container.is_backpack:
-            Logger.debug("Is backpack")
             template_equip_slot = ItemManager.get_inv_slot_by_type(item_template.inventory_type)
             if self.is_equipment_pos(dest_bag_slot, dest_slot) and dest_slot != template_equip_slot or \
                     self.is_bag_pos(dest_slot) and item_template.inventory_type != InventoryTypes.BAG or \
@@ -181,7 +180,6 @@ class InventoryManager(object):
 
         # Stack handling
         if dest_item:
-            Logger.debug("Dest item")
             if self.is_inventory_pos(dest_bag_slot, dest_slot):
                 if item_template.entry == dest_item.item_template.entry:
                     diff = dest_item.item_template.stackable - dest_item.item_instance.stackcount

--- a/game/world/managers/objects/player/InventoryManager.py
+++ b/game/world/managers/objects/player/InventoryManager.py
@@ -78,24 +78,158 @@ class InventoryManager(object):
     def get_backpack(self):
         return self.containers[InventorySlots.SLOT_INBACKPACK]
 
+    def get_container_slot_by_guid(self, container_guid):
+        for slot in self.containers.keys():
+            if self.containers[slot].guid == container_guid:
+                return slot
+        return InventorySlots.SLOT_INBACKPACK.value  # What is the logic behind backpack guid?
+
     def add_item(self, entry=0, item_template=None, count=1, handle_error=True):
         if entry != 0 and not item_template:
             item_template = WorldDatabaseManager.item_template_get_by_entry(entry)
 
+        items_added = False
         if item_template:
             if not self.can_store_item(item_template, count):
                 if handle_error:
                     self.send_equip_error(InventoryError.BAG_INV_FULL)
-                return None
+                return False
 
-            if count <= item_template.stackable:
+            # First, add to any pre-existing stacks
+            amount_left = count
+            for slot, container in self.containers.items():
+                for x in range(container.start_slot, container.max_slot):
+                    if self.is_bank_slot(slot, x):
+                        continue
+                    if x not in container.sorted_slots:
+                        continue  # Skip any reserved slots
+                    item_mgr = container.sorted_slots[x]
+                    if item_mgr.item_template.entry == item_template.entry:
+                        stack_missing = item_template.stackable - item_mgr.item_instance.stackcount
+                        if stack_missing >= amount_left:
+                            item_mgr.item_instance.stackcount += amount_left
+                            amount_left = 0
+                            items_added = True
+                            RealmDatabaseManager.character_inventory_update_item(item_mgr.item_instance)
+                            break
+                        else:
+                            item_mgr.item_instance.stackcount += stack_missing
+                            amount_left -= stack_missing
+                            RealmDatabaseManager.character_inventory_update_item(item_mgr.item_instance)
+                            items_added = True
+
+            # Add the remaining stack(s) to empty slots.
+            if amount_left > 0:
                 for slot, container in self.containers.items():
                     if not container.is_full():
-                        item_mgr = container.add_item(item_template)
-                        if item_mgr:
-                            self.owner.send_update_self()
-                            return item_mgr
-        return None
+                        if amount_left > item_template.stackable:
+                            container.add_item(item_template, count=item_template.stackable)
+                            amount_left -= item_template.stackable
+                            items_added = True
+                        else:
+                            container.add_item(item_template, count=amount_left)
+                            items_added = True
+                            break
+
+        if items_added:
+            self.owner.send_update_self()
+        return items_added
+
+    def add_item_to_slot(self, dest_bag_slot, dest_slot, entry=0, item_template=None, count=1, handle_error=True):
+        if dest_bag_slot not in self.containers:
+            if handle_error:
+                self.send_equip_error(InventoryError.BAG_ITEM_NOT_FOUND)
+            return
+        if entry != 0 and not item_template:
+            item_template = WorldDatabaseManager.item_template_get_by_entry(entry)
+        if not item_template:
+            if handle_error:
+                self.send_equip_error(InventoryError.BAG_ITEM_NOT_FOUND)
+            return
+
+        if not self.can_store_item(item_template, count):
+            if handle_error:
+                self.send_equip_error(InventoryError.BAG_INV_FULL)
+            return
+
+        dest_container = self.containers[dest_bag_slot]
+        dest_item = dest_container.get_item(dest_slot)
+
+        if not self.owner.is_alive:
+            if handle_error:
+                self.send_equip_error(InventoryError.BAG_NOT_WHILE_DEAD, None, dest_item)
+            return
+
+        # Destination slot checks
+        if dest_container.is_backpack:
+            Logger.debug("Is backpack")
+            template_equip_slot = ItemManager.get_inv_slot_by_type(item_template.inventory_type)
+            if self.is_equipment_pos(dest_bag_slot, dest_slot) and dest_slot != template_equip_slot or \
+                    self.is_bag_pos(dest_slot) and item_template.inventory_type != InventoryTypes.BAG or \
+                    dest_slot == 255:  # slot 255 is the backpack slot
+                if handle_error:
+                    self.send_equip_error(InventoryError.BAG_SLOT_MISMATCH, None, dest_item)
+                return
+
+        # Check backpack / paperdoll placement
+        if item_template.required_level > self.owner.level and \
+                self.is_equipment_pos(dest_bag_slot, dest_slot):
+            # Not enough level
+            if handle_error:
+                self.send_equip_error(InventoryError.BAG_LEVEL_MISMATCH, None, dest_item, item_template.required_level)
+            return
+
+        # Stack handling
+        if dest_item:
+            Logger.debug("Dest item")
+            if self.is_inventory_pos(dest_bag_slot, dest_slot):
+                if item_template.entry == dest_item.item_template.entry:
+                    diff = dest_item.item_template.stackable - dest_item.item_instance.stackcount
+                    if diff >= count:
+                        dest_item.item_instance.stackcount += count
+                    else:
+                        # Update stack values
+                        # Case where an item is dragged to stack but there's no space.
+                        # Test on later version shows that the items will go to another stack if there's space
+                        dest_item.item_instance.stackcount += diff
+                        self.add_item(item_template=item_template, count=count-diff, handle_error=False)
+
+                    self.owner.send_update_self()
+                    RealmDatabaseManager.character_inventory_update_item(dest_item.item_instance)
+                    return True
+                else:
+                    if handle_error:
+                        self.send_equip_error(InventoryError.BAG_CANT_STACK, None, dest_item)
+                    return
+            else:
+                if handle_error:
+                    self.send_equip_error(InventoryError.BAG_SLOT_MISMATCH, None, dest_item)
+                return
+
+        # Drags to bag slots
+        if dest_slot == 255:
+            if item_template.inventory_type == InventoryTypes.BAG:
+                self.add_bag(dest_slot, ItemManager.generate_item(item_template, self.owner.guid, dest_bag_slot,
+                                                                  dest_slot))
+                self.owner.send_update_self()
+                return True
+            else:
+                if handle_error:
+                    self.send_equip_error(InventoryError.BAG_SLOT_MISMATCH, None, dest_item)
+                return
+
+        # Add item
+        dest_container.set_item(item_template, dest_slot, count)
+
+        # Update attack time
+        if dest_slot == InventorySlots.SLOT_MAINHAND:
+            self.set_base_attack_time()
+
+        if self.is_equipment_pos(dest_bag_slot, dest_slot):
+            self.owner.flagged_for_update = True
+        else:
+            self.owner.send_update_self()
+        return True
 
     def swap_item(self, source_bag, source_slot, dest_bag, dest_slot):
         if source_bag not in self.containers or dest_bag not in self.containers:
@@ -142,12 +276,14 @@ class InventoryManager(object):
                         return
 
                     # Wrong destination slot
-                    if dest_item.item_template.class_ == InventoryTypes.BAG and self.is_equipment_pos(source_bag, source_slot):
+                    if dest_item.item_template.class_ == InventoryTypes.BAG and self.is_equipment_pos(source_bag,
+                                                                                                      source_slot):
                         self.send_equip_error(InventoryError.BAG_SLOT_MISMATCH, source_item, dest_item)
                         return
 
             # Prevent non empty bag in bag
-            if (source_container.is_backpack or source_item and source_item.is_container()) and self.is_bag_pos(source_slot) \
+            if (source_container.is_backpack or source_item and source_item.is_container()) \
+                    and self.is_bag_pos(source_slot) \
                     and source_item and not source_item.is_empty():
                 self.send_equip_error(InventoryError.BAG_NO_BAGS_IN_BAGS, source_item, dest_item)
                 return
@@ -281,16 +417,27 @@ class InventoryManager(object):
         # Reached unique limit
         if 0 < item_template.max_count <= self.get_item_count(item_template.entry):
             return False
-
-        # Check backpack or bank
+        # Check bags
         if not on_bank:
-            for x in range(InventorySlots.SLOT_ITEM_START, InventorySlots.SLOT_ITEM_END):
-                if x not in self.get_backpack().sorted_slots:
-                    amount -= item_template.stackable
+            for slot, container in self.containers.items():
+                for x in range(container.start_slot, container.max_slot):
+                    if self.is_bank_slot(slot, x):
+                        continue
+                    if x not in container.sorted_slots:
+                        amount -= item_template.stackable
+                        continue  # Skip any reserved slots
+                    item_mgr = container.sorted_slots[x]
+                    if item_mgr.item_template.entry == item_template.entry:
+                        amount -= item_template.stackable - item_mgr.item_instance.stackcount
         else:
-            for x in range(InventorySlots.SLOT_BANK_ITEM_START, InventorySlots.SLOT_BANK_ITEM_END):
+            for x in range(InventorySlots.SLOT_BANK_ITEM_START, InventorySlots.SLOT_ITEM_BANK_END):
                 if x not in self.get_backpack().sorted_slots:
                     amount -= item_template.stackable
+                    continue
+                item_mgr = self.get_backpack().sorted_slots[x]
+                if item_mgr.item_template.entry == item_template.entry:
+                    amount -= item_template.stackable - item_mgr.item_instance.stackcount
+
         if amount <= 0:
             return True
 

--- a/game/world/opcode_handling/Definitions.py
+++ b/game/world/opcode_handling/Definitions.py
@@ -43,6 +43,7 @@ from game.world.opcode_handling.handlers.ListInventoryHandler import ListInvento
 from game.world.opcode_handling.handlers.BuyItemHandler import BuyItemHandler
 from game.world.opcode_handling.handlers.AttackSwingHandler import AttackSwingHandler
 from game.world.opcode_handling.handlers.SellItemHandler import SellItemHandler
+from game.world.opcode_handling.handlers.BuyItemInSlotHandler import BuyItemInSlotHandler
 
 from game.world.opcode_handling.handlers.MovementHandler import MovementHandler
 

--- a/game/world/opcode_handling/Definitions.py
+++ b/game/world/opcode_handling/Definitions.py
@@ -97,6 +97,7 @@ HANDLER_DEFINITIONS = {
     OpCode.CMSG_PETITION_BUY: PetitionBuyHandler.handle,
     OpCode.CMSG_LIST_INVENTORY: ListInventoryHandler.handle,
     OpCode.CMSG_BUY_ITEM: BuyItemHandler.handle,
+    OpCode.CMSG_BUY_ITEM_IN_SLOT: BuyItemInSlotHandler.handle,
     OpCode.CMSG_ATTACKSWING: AttackSwingHandler.handle,
     OpCode.CMSG_SELL_ITEM: SellItemHandler.handle,
 

--- a/game/world/opcode_handling/handlers/BuyItemInSlotHandler.py
+++ b/game/world/opcode_handling/handlers/BuyItemInSlotHandler.py
@@ -1,0 +1,52 @@
+from struct import pack, unpack
+
+from database.world.WorldDatabaseManager import WorldDatabaseManager
+from game.world.managers.GridManager import GridManager
+from network.packet.PacketWriter import *
+from utils.Logger import Logger
+from utils.constants.ObjectCodes import BuyResults
+
+
+class BuyItemInSlotHandler(object):
+
+    @staticmethod
+    def handle(world_session, socket, reader):
+        Logger.debug(str(len(reader.data)))
+        if len(reader.data) >= 22:  # Avoid handling empty buy item packet
+            vendor_guid, item, bag_guid, slot, count = unpack('<QIQBB', reader.data[:22])
+            if 0 < vendor_guid == world_session.player_mgr.current_selection:
+                if count <= 0:
+                    count = 1
+
+                Logger.info("buy in slot data: " + str(vendor_guid) + ", " + str(item) + ", " + str(bag_guid) + ", " + str(slot))
+                vendor_npc = GridManager.get_surrounding_unit_by_guid(world_session.player_mgr, vendor_guid)
+
+                vendor_data, session = WorldDatabaseManager.creature_get_vendor_data_by_item(vendor_npc.entry, item)
+
+                if vendor_data:
+                    item_template = vendor_data.item_template
+                    session.close()
+
+                    total_cost = item_template.buy_price * count
+
+                    if world_session.player_mgr.coinage < total_cost:
+                        world_session.player_mgr.inventory.send_buy_error(BuyResults.BUY_ERR_NOT_ENOUGH_MONEY, item,
+                                                                          vendor_guid)
+                        return 0
+
+                    if 0 < vendor_data.maxcount < count:  # I should be checking here for current count too
+                        world_session.player_mgr.inventory.send_buy_error(BuyResults.BUY_ERR_ITEM_SOLD_OUT, item,
+                                                                          vendor_guid)
+                        return 0
+
+                    bag_slot = world_session.player_mgr.inventory.get_container_slot_by_guid(bag_guid)
+                    Logger.info(bag_slot)
+                    if world_session.player_mgr.inventory.add_item_to_slot(dest_bag_slot=bag_slot, dest_slot=slot,
+                                                                           item_template=item_template, count=count):
+                        world_session.player_mgr.mod_money(total_cost * -1)
+                        #vendor_npc.send_inventory_list(world_session)
+                else:
+                    world_session.player_mgr.inventory.send_buy_error(BuyResults.BUY_ERR_CANT_FIND_ITEM, item,
+                                                                      vendor_guid)
+
+        return 0

--- a/game/world/opcode_handling/handlers/BuyItemInSlotHandler.py
+++ b/game/world/opcode_handling/handlers/BuyItemInSlotHandler.py
@@ -3,7 +3,6 @@ from struct import pack, unpack
 from database.world.WorldDatabaseManager import WorldDatabaseManager
 from game.world.managers.GridManager import GridManager
 from network.packet.PacketWriter import *
-from utils.Logger import Logger
 from utils.constants.ObjectCodes import BuyResults
 
 
@@ -11,14 +10,12 @@ class BuyItemInSlotHandler(object):
 
     @staticmethod
     def handle(world_session, socket, reader):
-        Logger.debug(str(len(reader.data)))
         if len(reader.data) >= 22:  # Avoid handling empty buy item packet
             vendor_guid, item, bag_guid, slot, count = unpack('<QIQBB', reader.data[:22])
             if 0 < vendor_guid == world_session.player_mgr.current_selection:
                 if count <= 0:
                     count = 1
 
-                Logger.info("buy in slot data: " + str(vendor_guid) + ", " + str(item) + ", " + str(bag_guid) + ", " + str(slot))
                 vendor_npc = GridManager.get_surrounding_unit_by_guid(world_session.player_mgr, vendor_guid)
 
                 vendor_data, session = WorldDatabaseManager.creature_get_vendor_data_by_item(vendor_npc.entry, item)
@@ -40,7 +37,6 @@ class BuyItemInSlotHandler(object):
                         return 0
 
                     bag_slot = world_session.player_mgr.inventory.get_container_slot_by_guid(bag_guid)
-                    Logger.info(bag_slot)
                     if world_session.player_mgr.inventory.add_item_to_slot(dest_bag_slot=bag_slot, dest_slot=slot,
                                                                            item_template=item_template, count=count):
                         world_session.player_mgr.mod_money(total_cost * -1)


### PR DESCRIPTION
add_item now also returns a boolean instead of the item since it can end up in multiple stacks. There are also some small minor formatting changes to make lines more readable.
Add_item_to_slot is mainly based on functionality that I've observed on other servers, what actions have error messages tied to them and what feels intuitive.